### PR TITLE
fix(ci): pin webfactory/ssh-agent action to immutable commit SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     needs: build
     steps:
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
### Motivation
- Mitigate a supply‑chain risk where the deploy workflow referenced `webfactory/ssh-agent@v0.9.0` (a mutable tag) while loading `secrets.SSH_PRIVATE_KEY`, which could allow secret exfiltration if the tag is retargeted or upstream is compromised.

### Description
- Replace the mutable tag in `.github/workflows/deploy.yml` with the action's immutable commit SHA `webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387` while preserving the same behavior (corresponds to `v0.9.0`).

### Testing
- Verified the workflow file was updated using automated file checks and confirmed the `uses:` reference now contains the immutable SHA; no unit or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c454643970833188abe3aac57a031c)